### PR TITLE
Add posts with likes, dislikes, and comments

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,10 @@ func main() {
 	http.HandleFunc("/logout", utils.LogoutHandler)
 	http.HandleFunc("/guest", utils.GuestHandler)
 	http.HandleFunc("/register", utils.RegisterHandler)
+	http.HandleFunc("/posts", utils.PostsHandler)
+	http.HandleFunc("/like", utils.LikeHandler)
+	http.HandleFunc("/dislike", utils.DislikeHandler)
+	http.HandleFunc("/comment", utils.CommentHandler)
 
 	log.Println("Server running on http://localhost:8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/templates/posts.html
+++ b/templates/posts.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Posts</title>
+    <link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+    <h1>Posts</h1>
+    <form method="post" action="/posts">
+        <input type="text" name="title" placeholder="Title" required>
+        <br>
+        <textarea name="content" placeholder="Content" required></textarea>
+        <br>
+        <button type="submit">Create Post</button>
+    </form>
+    <hr>
+    {{range .}}
+    <article>
+        <h2>{{.Title}}</h2>
+        <p>{{.Content}}</p>
+        <p><em>by {{.Author.Username}}</em></p>
+        <form method="post" action="/like" style="display:inline;">
+            <input type="hidden" name="post_id" value="{{.ID}}">
+            <button type="submit">👍 {{len .Likes}}</button>
+        </form>
+        <form method="post" action="/dislike" style="display:inline;">
+            <input type="hidden" name="post_id" value="{{.ID}}">
+            <button type="submit">👎 {{len .DisLikes}}</button>
+        </form>
+        <div>
+            <h3>Comments ({{len .Comments}})</h3>
+            <ul>
+                {{range .Comments}}
+                <li><strong>{{.Author.Username}}:</strong> {{.Content}}</li>
+                {{end}}
+            </ul>
+            <form method="post" action="/comment">
+                <input type="hidden" name="post_id" value="{{.ID}}">
+                <input type="text" name="content" placeholder="Add comment" required>
+                <button type="submit">Comment</button>
+            </form>
+        </div>
+    </article>
+    <hr>
+    {{end}}
+</body>
+</html>

--- a/utils/posts.go
+++ b/utils/posts.go
@@ -1,0 +1,91 @@
+package utils
+
+// CreatePost inserts a new post into the database.
+func (db *DataBase) CreatePost(authorUUID, title, content string) error {
+	_, err := db.Conn.Exec("INSERT INTO posts (title, content, author_uuid) VALUES (?, ?, ?)", title, content, authorUUID)
+	return err
+}
+
+// AddComment adds a new comment to a post.
+func (db *DataBase) AddComment(authorUUID string, postID int, content string) error {
+	_, err := db.Conn.Exec("INSERT INTO comments (content, comment_author_uuid, post_id) VALUES (?, ?, ?)", content, authorUUID, postID)
+	return err
+}
+
+// ToggleLike records a like or dislike for a post from a user.
+// If like is true, it records a like; otherwise a dislike.
+// Existing interactions from the same user are removed before insertion.
+func (db *DataBase) ToggleLike(userUUID string, postID int, like bool) error {
+	db.Write.Lock()
+	defer db.Write.Unlock()
+
+	_, err := db.Conn.Exec("DELETE FROM interactions WHERE user_uuid = ? AND post_id = ?", userUUID, postID)
+	if err != nil {
+		return err
+	}
+
+	var liked, disliked bool
+	if like {
+		liked = true
+	} else {
+		disliked = true
+	}
+
+	_, err = db.Conn.Exec("INSERT INTO interactions (user_uuid, post_id, liked, disliked) VALUES (?, ?, ?, ?)", userUUID, postID, liked, disliked)
+	return err
+}
+
+// GetPosts retrieves all posts with their comments and interactions.
+func (db *DataBase) GetPosts() ([]Post, error) {
+	rows, err := db.Conn.Query("SELECT p.id, p.title, p.content, u.uuid, u.username FROM posts p JOIN users u ON p.author_uuid = u.uuid ORDER BY p.id DESC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var posts []Post
+	for rows.Next() {
+		var p Post
+		var auuid, ausername string
+		if err := rows.Scan(&p.ID, &p.Title, &p.Content, &auuid, &ausername); err != nil {
+			return nil, err
+		}
+		p.Author = User{UUID: auuid, Username: ausername}
+
+		// Fetch comments for the post
+		cRows, err := db.Conn.Query("SELECT c.id, c.content, u.uuid, u.username FROM comments c JOIN users u ON c.comment_author_uuid = u.uuid WHERE c.post_id = ?", p.ID)
+		if err == nil {
+			for cRows.Next() {
+				var c Comment
+				var cuuid, cusername string
+				if err := cRows.Scan(&c.ID, &c.Content, &cuuid, &cusername); err == nil {
+					c.Author = User{UUID: cuuid, Username: cusername}
+					p.Comments = append(p.Comments, c)
+				}
+			}
+			cRows.Close()
+		}
+
+		// Fetch likes and dislikes
+		iRows, err := db.Conn.Query("SELECT user_uuid, liked, disliked FROM interactions WHERE post_id = ?", p.ID)
+		if err == nil {
+			for iRows.Next() {
+				var inter Interaction
+				if err := iRows.Scan(&inter.User.UUID, &inter.Like, &inter.DisLike); err == nil {
+					if inter.Like {
+						p.Likes = append(p.Likes, inter)
+					} else if inter.DisLike {
+						p.DisLikes = append(p.DisLikes, inter)
+					}
+				}
+			}
+			iRows.Close()
+		}
+
+		posts = append(posts, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return posts, nil
+}


### PR DESCRIPTION
## Summary
- support creating and listing posts along with comments and interactions
- add handlers and routes for liking, disliking, and commenting on posts
- add template for displaying posts, reactions, and comment form

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ae416baf94833390221cb94c8f8863